### PR TITLE
Sorting, labels, priorities, robustness

### DIFF
--- a/bitbucket2gitlab.rb
+++ b/bitbucket2gitlab.rb
@@ -103,7 +103,7 @@ end
 
 logger.info "found #{data.issues.count} issues to migrate"
 
-data.issues.each do |bitbucket_issue|
+data.issues.sort{ |a, b| a.id <=> b.id }.each do |bitbucket_issue|
 
   # TODO: detect duplicates
 

--- a/bitbucket2gitlab.rb
+++ b/bitbucket2gitlab.rb
@@ -7,10 +7,11 @@ require 'logger'
 require 'pry'
 
 clients          = {}
-private_tokens   = {}
+private_tokens   = {'bitbucket_username' => 'gitlab_private_token',
+                    'bitbucket_collaborator2' => 'gitlab_collaborator_private_token'}
 issues_json_file = '/tmp/db-1.0.json'
-api_url          = ''
-project_name     = 'repos/test'
+api_url          = 'https://gitlab.example.net/api/v3'
+project_name     = 'repo/name'
 project          = nil
 
 MAP_ISSUE = {


### PR DESCRIPTION
I recently did a migration from Bitbucket to Gitlab and found this script to be far better than the one integrated into Gitlab's UI (which squashes messages due to reasonable permissions issues and doesn't pull in components or priorities).  Anyway, the changes here (which you can of course ignore, accept, or take bits and pieces of):
- Components and priorities are imported as (gray) labels
- The issue list is sorted to make the issue numbers match up
- Robustness in the face of missing data is somewhat better
- A bit of self-documentation with the initial setup needed in the constants

I also just noticed that "wontfix" is not properly propagated even in my version, but I guess that can be an exercise left to the next migrater :)
